### PR TITLE
Fix double space in template when year is blank

### DIFF
--- a/tmpl.go
+++ b/tmpl.go
@@ -142,7 +142,7 @@ const tmplMPL = `This Source Code Form is subject to the terms of the Mozilla Pu
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.`
 
-const tmplSPDX = `{{ if and .Year .Holder }}Copyright {{.Year}} {{.Holder}}
-{{ end }}SPDX-License-Identifier: {{.SPDXID}}`
+const tmplSPDX = `Copyright (c){{ if .Year }} {{.Year}}{{ end }}{{ if .Holder }} {{.Holder}}{{ end }}
+{{ if .SPDXID }}SPDX-License-Identifier: {{.SPDXID}}{{ end }}`
 
 const spdxSuffix = "\n\nSPDX-License-Identifier: {{.SPDXID}}"


### PR DESCRIPTION
This change updates the SPDX template to be as generic as possible, handling if:
 - No year is provided
 - No copyright holder is provided
 - No SPDX license ID is provided

Year, Holder, and SPDX ID is provided:
```
Copyright (c) 2022 HashiCorp, Inc.
SPDX-License-Identifier: MPL-2.0
```


Holder and SPDX but not year:
```
Copyright (c) HashiCorp, Inc.
SPDX-License-Identifier: MPL-2.0
```

Year and holder but no SPDX:
```
Copyright (c) 2022 HashiCorp, Inc.
```

I suppose we could change up what happens if no holder/year is provided, but that is not supposed to happen for HashiCorp, and `addLicense` intends you to set an `--spdx=only` flag in that scenario, which uses a completely different template anyhow
```
Copyright (c)
SPDX-LicenseIdentifier: MPL-2.0
```